### PR TITLE
Add compatibility with latest rpm

### DIFF
--- a/lib/rocket_pants/rpm.rb
+++ b/lib/rocket_pants/rpm.rb
@@ -1,7 +1,5 @@
 require "rocket_pants/rpm/version"
 require "newrelic_rpm"
-require 'new_relic/agent/instrumentation/rails3/action_controller'
-require 'new_relic/agent/instrumentation/rails4/action_controller'
 
 module RocketPants
   module RPM
@@ -24,7 +22,6 @@ module RocketPants
       executes do
         class RocketPants::Base
           include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-          include NewRelic::Agent::Instrumentation::Rails3::ActionController
         end
       end
     end
@@ -48,7 +45,6 @@ module RocketPants
         Rails.logger.info "running rpm execute"
         class RocketPants::Base
           include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-          include NewRelic::Agent::Instrumentation::Rails4::ActionController
         end
 
         ActiveSupport::Notifications.subscribe(/^process_action.rocket_pants$/,


### PR DESCRIPTION
This makes the gem compatible with `rpm` versions `3.9.2.239` and above. After upgrading, we stopped seeing any Transactions in New Relic.

[This](https://github.com/newrelic/rpm/commit/0ff10d983af224f91d2dea74e6e26ee5a852f91d) was the commit that introduced a breaking change. Using our fork of `rocket_pants-rpm` with the proposed changes resolved the issue in development and production.
