### PR TITLE
Make Newrelic track rocket_pants API endpoint on Rails 5 (5.0.2)

### DIFF
--- a/lib/rocket_pants/rpm.rb
+++ b/lib/rocket_pants/rpm.rb
@@ -1,7 +1,5 @@
 require "rocket_pants/rpm/version"
 require "newrelic_rpm"
-require 'new_relic/agent/instrumentation/rails3/action_controller'
-require 'new_relic/agent/instrumentation/rails4/action_controller'
 
 module RocketPants
   module RPM
@@ -24,7 +22,6 @@ module RocketPants
       executes do
         class RocketPants::Base
           include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-          include NewRelic::Agent::Instrumentation::Rails3::ActionController
         end
       end
     end
@@ -48,7 +45,6 @@ module RocketPants
         Rails.logger.info "running rpm execute"
         class RocketPants::Base
           include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-          include NewRelic::Agent::Instrumentation::Rails4::ActionController
         end
 
         ActiveSupport::Notifications.subscribe(/^process_action.rocket_pants$/,

--- a/lib/rocket_pants/rpm.rb
+++ b/lib/rocket_pants/rpm.rb
@@ -52,5 +52,31 @@ module RocketPants
       end
     end
 
+    DependencyDetection.defer do
+      @name = :rails5_rocketpants_controller
+
+      depends_on do
+        defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 5
+      end
+
+      depends_on do
+        defined?(RocketPants) && defined?(RocketPants::Base)
+      end
+
+      executes do
+        NewRelic::Agent.logger.debug 'Installing Rails 5 RocketPants Controller instrumentation'
+      end
+
+      executes do
+        Rails.logger.info "running rpm execute"
+        class RocketPants::Base
+          include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+        end
+
+        ActiveSupport::Notifications.subscribe(/^process_action.rocket_pants$/,
+          NewRelic::Agent::Instrumentation::ActionControllerSubscriber.new)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
On Rails 5, Newrelic ruby agent is not loaded anymore. this PR check Rails version, make sure agent is included in RocketPant::Base class


![screen shot 2017-03-21 at 3 33 15 pm](https://cloud.githubusercontent.com/assets/295515/24152990/86f16754-0e4d-11e7-9298-1c9a2863944f.png)


